### PR TITLE
Atualiza link para o SESC

### DIFF
--- a/beneficios.md
+++ b/beneficios.md
@@ -56,7 +56,7 @@ Para solicitar o cartão basta ir até a unidade mais próxima e apresentar:
 * Carteira de trabalho
 * Último holerite.
 
-Para mais informações acesse: [Sesc / Serviço Social do Comércio](http://www.sesc.com.br/portal/pagina_inicial)
+Para mais informações acesse: [Sesc / Serviço Social do Comércio](http://www.sesc.com.br/)
 
 ## Reembolso de despesas
 


### PR DESCRIPTION
Corrige o link antigo `https://www.sesc.com.br/portal/pagina_inicial` que atualmente aponta para uma página não encontrada.